### PR TITLE
Fix bug when handling readUnprotectedConfigRequest

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -785,7 +785,7 @@ export default class Store {
                             console.log(`${this.mainLog} did not find unprotected data file when trying read the key '${args.key}'. Creating an empty unprotected data file.`);
                         }
 
-                        const defaultData = JSON.parse({});
+                        const defaultData = JSON.stringify({});
 
                         fs.writeFileSync(unprotectedPath, defaultData);
                         browserWindow.webContents.send(readUnprotectedConfigResponse, {


### PR DESCRIPTION
The code was trying to parse a json object, it should be stringifying instead as the value is then written to disk as the initial value for the conf